### PR TITLE
Feat/issue-2-clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.5.39", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,10 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
-    #[arg(short, long)]
+    #[arg(index=1)]
     pub query: String,
 
-    #[arg(short, long)]
+    #[arg(index=2)]
     pub filename: String,
 
     #[arg(short, long)]
@@ -91,9 +91,66 @@ safe, fast, productive.
 Trust me.";
 
         assert_eq!(
-            vec!["Rust", "Trust, me."],
-            search(query, contents)
+            vec!["Rust:", "Trust me."],
+            search_case_insensitive(query, contents)
         );
 
+    }
+
+    // clapによる引数パースのテスト
+    #[test]
+    fn parse_args_basic() {
+        let args = Args::try_parse_from(&["minigrep", "test", "sample.txt"]).unwrap();
+        assert_eq!(args.query, "test");
+        assert_eq!(args.filename, "sample.txt");
+        assert_eq!(args.ignore_case, false);
+    }
+
+    #[test]
+    fn parse_args_with_ignore_case_short() {
+        let args = Args::try_parse_from(&["minigrep", "test", "sample.txt", "-i"]).unwrap();
+        assert_eq!(args.query, "test");
+        assert_eq!(args.filename, "sample.txt");
+        assert_eq!(args.ignore_case, true);
+    }
+
+    #[test]
+    fn parse_args_with_ignore_case_long() {
+        let args = Args::try_parse_from(&["minigrep", "test", "sample.txt", "--ignore-case"]).unwrap();
+        assert_eq!(args.query, "test");
+        assert_eq!(args.filename, "sample.txt");
+        assert_eq!(args.ignore_case, true);
+    }
+
+    #[test]
+    fn parse_args_flag_before_positional() {
+        let args = Args::try_parse_from(&["minigrep", "-i", "test", "sample.txt"]).unwrap();
+        assert_eq!(args.query, "test");
+        assert_eq!(args.filename, "sample.txt");
+        assert_eq!(args.ignore_case, true);
+    }
+
+    #[test]
+    fn parse_args_missing_filename() {
+        let result = Args::try_parse_from(&["minigrep", "test"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_args_missing_query() {
+        let result = Args::try_parse_from(&["minigrep"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_args_too_many_args() {
+        let result = Args::try_parse_from(&["minigrep", "test", "sample.txt", "extra"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_args_unknown_flag() {
+        let result = Args::try_parse_from(&["minigrep", "test", "sample.txt", "--unknown"]);
+        assert!(result.is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,13 @@
 extern crate minigrep;
-use std::env;
 use std::process;
+use clap::Parser;
 
-use minigrep::Config;
+use minigrep::Args;
 fn main() {
-    // 引数を文字列型を格納するベクトルとして集結させる
-    let args: Vec<String> = env::args().collect();
+    // 引数をパースする
+    let args = Args::parse();
     
-    // Configのnewを呼び出してインスタンスを生成
-    let config = Config::new(&args).unwrap_or_else(|err|{
-        println!("Problem parsing arguments: {}", err);
-        process::exit(1);
-    });
-    
-    if let Err(e) = minigrep::run(config) {
+    if let Err(e) = minigrep::run(args) {
         println!("Application error: {}", e);
         // エラーコード1で終了する
         process::exit(1);


### PR DESCRIPTION
- 引数パースにclapクレートを使用
- クエリとファイル名は位置引数
- ignore_caseは`-i`もしくは`--case_insensitive`で指定